### PR TITLE
Retry vitess connection refused errors 100 times

### DIFF
--- a/src/main/java/io/debezium/connector/vitess/VitessErrorHandler.java
+++ b/src/main/java/io/debezium/connector/vitess/VitessErrorHandler.java
@@ -12,8 +12,11 @@ import io.debezium.connector.base.ChangeEventQueue;
 import io.debezium.pipeline.ErrorHandler;
 import io.grpc.StatusRuntimeException;
 
+import java.util.concurrent.atomic.AtomicReference;
+
 public class VitessErrorHandler extends ErrorHandler {
     private static final Logger LOGGER = LoggerFactory.getLogger(VitessErrorHandler.class);
+    private static AtomicReference<Integer> connectionRefusedRestarts = new AtomicReference<>();
 
     public VitessErrorHandler(VitessConnectorConfig connectorConfig, ChangeEventQueue<?> queue) {
         super(VitessConnector.class, connectorConfig, queue);
@@ -34,6 +37,9 @@ public class VitessErrorHandler extends ErrorHandler {
                     }
                     return false;
                 case UNAVAILABLE:
+                    if (throwable.getCause().toString().contains("AnnotatedConnectException: Connection refused")) {
+                        return handleConnectionRefusedException();
+                    }
                     return true;
                 case UNKNOWN:
                     // Stream timeout error due to idle VStream or vstream ended unexpectedly.
@@ -45,6 +51,19 @@ public class VitessErrorHandler extends ErrorHandler {
                     }
                     return false;
             }
+        }
+        return false;
+    }
+
+    private boolean handleConnectionRefusedException() {
+        Integer restarts = connectionRefusedRestarts.get();
+        if (restarts == null) {
+            connectionRefusedRestarts.set(1);
+            return true;
+        }
+        if (restarts < 100) {
+            connectionRefusedRestarts.set(restarts + 1);
+            return true;
         }
         return false;
     }

--- a/src/test/java/io/debezium/connector/vitess/VitessErrorHandlerTest.java
+++ b/src/test/java/io/debezium/connector/vitess/VitessErrorHandlerTest.java
@@ -1,0 +1,43 @@
+package io.debezium.connector.vitess;
+
+import io.debezium.connector.base.ChangeEventQueue;
+import io.debezium.pipeline.DataChangeEvent;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class VitessErrorHandlerTest  {
+
+    VitessConnectorConfig config = new VitessConnectorConfig(TestHelper.defaultConfig().build());
+    ChangeEventQueue<DataChangeEvent> queue = new ChangeEventQueue.Builder<DataChangeEvent>().build();
+    VitessErrorHandler vitessErrorHandler = new VitessErrorHandler(config, queue);
+
+    @Test
+    public void isRetriable_returnsTrueForConnectionRefusedExceptionThat() {
+        boolean result = vitessErrorHandler.isRetriable(createConnectionRefusedException());
+        assertTrue(result);
+    }
+
+    @Test
+    public void isRetriable_ReturnsFalseAfter100Retries() {
+        for (int i = 0; i < 100; i++) {
+            vitessErrorHandler.isRetriable(createConnectionRefusedException());
+        }
+        assertFalse(vitessErrorHandler.isRetriable(createConnectionRefusedException()));
+    }
+
+    private StatusRuntimeException createConnectionRefusedException() {
+        Throwable connectionRefused = new AnnotatedConnectException("Connection refused");
+        return Status.UNAVAILABLE.withDescription("io exception").withCause(connectionRefused).asRuntimeException();
+    }
+
+    // mocks com.ververica.cdc.connectors.vitess.shaded.io.netty.channel.AbstractChannel$AnnotatedConnectException
+    static class AnnotatedConnectException extends RuntimeException {
+        public AnnotatedConnectException(String message) {
+            super(message);
+        }
+    }
+}


### PR DESCRIPTION
Debezium embedded engine got connection refused from vtgate and started a crashback loop for uk portal. We've decided to limit the number of retries for this specific error. I've limited to a 100, because we have seen errors of up to 25 cases in a quick succession, probably due to network issues. 

made the connectionRefusedRestarts atomic because VitessErrorHandler is marked as `volatile` in VitessConnectorTask

```
VStream streaming for keyspace:cstool_main and tables: cstool_main.levels  onError. Status: Status{code=UNAVAILABLE, description=io exception, cause=com.ververica.cdc.connectors.vitess.shaded.io.netty.channel.AbstractChannel$AnnotatedConnectException: Connection refused: vtgate-dwh-cstool.vtgate-dwh.svc.prod3.k8s.vinted.com/10.125.153.62:15991
Caused by: java.net.ConnectException: Connection refused
	at java.base/sun.nio.ch.SocketChannelImpl.checkConnect(Native Method)
	at java.base/sun.nio.ch.SocketChannelImpl.finishConnect(Unknown Source)
	...
}
```